### PR TITLE
smf_bearer_add tests

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -20,7 +20,12 @@
 #ifndef SMF_CONTEXT_H
 #define SMF_CONTEXT_H
 
-#include "smf-config.h"
+// #include "smf-config.h"
+#define HAVE_NETINET_ICMP6_H 1
+#define HAVE_NETINET_IP6_H 1
+#define HAVE_NETINET_IP_H 1
+#define HAVE_NETINET_IP_ICMP_H 1
+#define HAVE_NET_IF_H 1
 
 #include "ogs-gtp.h"
 #include "ogs-diameter-gx.h"

--- a/tests/unit/abts-main.c
+++ b/tests/unit/abts-main.c
@@ -37,6 +37,7 @@ abts_suite *test_ngap_message(abts_suite *suite);
 abts_suite *test_sbi_message(abts_suite *suite);
 abts_suite *test_security(abts_suite *suite);
 abts_suite *test_crash(abts_suite *suite);
+abts_suite *test_smf_bearer_add(abts_suite *suite);
 
 const struct testlist {
     abts_suite *(*func)(abts_suite *suite);
@@ -49,6 +50,7 @@ const struct testlist {
     {test_sbi_message},
     {test_security},
     {test_crash},
+    {test_smf_bearer_add},
     {NULL},
 };
 

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -25,15 +25,18 @@ testunit_unit_sources = files('''
     sbi-message-test.c
     security-test.c
     crash-test.c
+    smf_bearer_add-test.c
 '''.split())
 
 testunit_unit_exe = executable('unit',
     sources : testunit_unit_sources,
     c_args : [testunit_core_cc_flags, sbi_cc_flags],
+    include_directories : [srcinc, libinc, testinc],
     dependencies : [libs1ap_dep,
                     libgtp_dep,
                     libngap_dep,
                     libnas_eps_dep,
-                    libsbi_dep])
+                    libsbi_dep,
+                    libsmf_dep])
 
 test('unit', testunit_unit_exe, is_parallel : false, suite: 'unit')

--- a/tests/unit/smf_bearer_add-test.c
+++ b/tests/unit/smf_bearer_add-test.c
@@ -1,0 +1,40 @@
+#include "core/abts.h"
+#include "ogs-core.h"
+#include "smf/context.h"
+
+
+static void smf_bearer_add_test_psi(abts_case *tc, void *data)
+{
+    smf_context_init();
+
+    smf_ue_t *ue = smf_ue_add_by_imsi("1", 1);
+    ABTS_PTR_NOTNULL(tc, ue);
+
+    smf_sess_t *sess = smf_sess_add_by_psi(ue, 123);
+    ABTS_PTR_NOTNULL(tc, sess);
+    sess->session.session_type = OGS_PDU_SESSION_TYPE_IPV4;
+    
+    smf_bearer_t *bearer  = smf_bearer_add(sess);
+    ABTS_PTR_NOTNULL(tc, bearer);
+
+    ABTS_PTR_NOTNULL(tc, bearer->dl_pdr);
+    ABTS_PTR_NOTNULL(tc, bearer->ul_pdr);
+    ABTS_PTR_NOTNULL(tc, bearer->dl_far);
+    ABTS_PTR_NOTNULL(tc, bearer->ul_far);
+
+    ABTS_INT_EQUAL(tc, bearer->sess_id, sess->id);
+    ABTS_INT_EQUAL(tc, bearer->ul_pdr->outer_header_removal.description, OGS_PFCP_OUTER_HEADER_REMOVAL_GTPU_UDP_IPV4);
+
+    smf_context_final();
+}
+
+
+
+abts_suite *test_smf_bearer_add(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite)
+
+    abts_run_test(suite, smf_bearer_add_test_psi, NULL);
+
+    return suite;
+}


### PR DESCRIPTION
Nie byłem w stanie doprowadzić **smf_ue_add** ani **smf_sess_add** do działania przez odpowiednio:
* ERROR: Maximum number of smf_ue[0] reached
* ERROR: Maximum number of session[0] reached


Nie odpala się inicjalizacja configu w unit testach i nie potrafiłem tego zmienić (funkcja **ogs_app_initialize**).